### PR TITLE
Ops 5171 fix empty outputs for delete personal instance

### DIFF
--- a/roles/delete_nodepools/tasks/main.yml
+++ b/roles/delete_nodepools/tasks/main.yml
@@ -11,31 +11,19 @@
 
 - name: Debug node pool IDs
   debug:
-      msg: "pool_id: {{ item }}"
-  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
-  loop_control:
-      loop_var: item
-
-- name: Debug k8s_cluster_id
-  debug:
-      msg: "k8s_cluster_id: {{ terraform_run.outputs.cluster_id.value }}"
-  when: terraform_run.outputs.cluster_id.value is defined
-
-- name: Debug node pool IDs
-  debug:
       var: pool_id
-  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
+  loop: "{{ terraform_run.outputs.nodepool_zone1_id.value + terraform_run.outputs.nodepool_zone2_id.value }}"
   loop_control:
       loop_var: pool_id
-
+      
 - name: Delete k8s cluster nodepool
   ionoscloudsdk.ionoscloud.k8s_nodepool:
-      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default(omit) }}"
+      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value }}"
       nodepool_id: "{{ pool_id }}"
       username: "{{ ionos_username }}"
       password: "{{ ionos_password }}"
       state: absent
-  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
+  loop: "{{ terraform_run.outputs.nodepool_zone1_id.value + terraform_run.outputs.nodepool_zone2_id.value }}"
   loop_control:
     loop_var: pool_id
-  when: not ansible_check_mode and k8s_cluster_id is defined 
+  when: not ansible_check_mode or terraform_run.outputs.cluster_id.value is not defined

--- a/roles/delete_nodepools/tasks/main.yml
+++ b/roles/delete_nodepools/tasks/main.yml
@@ -5,40 +5,30 @@
 #To avoid accidental node pool deletions during an Ansible run in check mode, make use of when: not ansible_check_mode.
 # See https://docs.ionos.com/ansible/api/managed-kubernetes/k8s_nodepool
 
----
 - name: Run Terraform
   import_role:
     name: dbildungscloud.infra.resource_pool
 
 - name: Debug node pool IDs
   debug:
-      var: pool_id
+      msg: "pool_id: {{ item }}"
   loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
   loop_control:
-      loop_var: pool_id
+      loop_var: item
 
-
-
-#- name: Delete k8s cluster nodepool
-#  ionoscloudsdk.ionoscloud.k8s_nodepool:
-#      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default(omit) }}"
-#      nodepool_id: "{{ pool_id }}"
-#      username: "{{ ionos_username }}"
-#      password: "{{ ionos_password }}"
-#      state: absent
-#  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
-#  loop_control:
-#    loop_var: pool_id
-#  when: not ansible_check_mode # and terraform_run.outputs.cluster_id.value is defined and item is defined
+- name: Debug k8s_cluster_id
+  debug:
+      msg: "k8s_cluster_id: {{ terraform_run.outputs.cluster_id.value }}"
+  when: terraform_run.outputs.cluster_id.value is defined
 
 - name: Delete k8s cluster nodepool
   ionoscloudsdk.ionoscloud.k8s_nodepool:
-      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default() }}"
-      nodepool_id: "{{ pool_id }}"
+      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default(omit) }}"
+      nodepool_id: "{{ item }}"
       username: "{{ ionos_username }}"
       password: "{{ ionos_password }}"
       state: absent
-  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default() + terraform_run.outputs.nodepool_zone2_id.value | default()] }}"
+  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
   loop_control:
-    loop_var: pool_id
-    when: not ansible_check_mode and k8s_cluster_id is defined and pool_id is defined
+    loop_var: item
+  when: not ansible_check_mode and terraform_run.outputs.cluster_id.value is defined and item is defined

--- a/roles/delete_nodepools/tasks/main.yml
+++ b/roles/delete_nodepools/tasks/main.yml
@@ -21,14 +21,21 @@
       msg: "k8s_cluster_id: {{ terraform_run.outputs.cluster_id.value }}"
   when: terraform_run.outputs.cluster_id.value is defined
 
+- name: Debug node pool IDs
+  debug:
+      var: pool_id
+  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
+  loop_control:
+      loop_var: pool_id
+
 - name: Delete k8s cluster nodepool
   ionoscloudsdk.ionoscloud.k8s_nodepool:
       k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default(omit) }}"
-      nodepool_id: "{{ item }}"
+      nodepool_id: "{{ pool_id }}"
       username: "{{ ionos_username }}"
       password: "{{ ionos_password }}"
       state: absent
   loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
   loop_control:
-    loop_var: item
-  when: not ansible_check_mode and terraform_run.outputs.cluster_id.value is defined and item is defined
+    loop_var: pool_id
+  when: not ansible_check_mode and k8s_cluster_id is defined 

--- a/roles/delete_nodepools/tasks/main.yml
+++ b/roles/delete_nodepools/tasks/main.yml
@@ -5,32 +5,57 @@
 #To avoid accidental node pool deletions during an Ansible run in check mode, make use of when: not ansible_check_mode.
 # See https://docs.ionos.com/ansible/api/managed-kubernetes/k8s_nodepool
 
+---
+###################### Destroy Nodepools ##########################################################
+#Using the Ansible module ionoscloudsdk.ionoscloud.k8s_nodepool to destroy a node pool, it's important
+#to note that the module will perform the deletion whether you run it with or without the -C flag.
+#To avoid accidental node pool deletions during an Ansible run in check mode, make use of when: not ansible_check_mode.
+# See https://docs.ionos.com/ansible/api/managed-kubernetes/k8s_nodepool
+
 - name: Run Terraform
   import_role:
     name: dbildungscloud.infra.resource_pool
 
-- name: Use Terraform output in variables
-  ansible.builtin.set_fact:
-      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value }}"
-      nodepool_zone1_id: "{{ terraform_run.outputs.nodepool_zone1_id.value }}"
-      nodepool_zone2_id: "{{ terraform_run.outputs.nodepool_zone2_id.value }}"
+- name: Debug node pool IDs
+  debug:
+      msg: "pool_id: {{ item }}"
+  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit), terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
+  loop_control:
+      loop_var: item
+
+- name: Debug k8s_cluster_id
+  debug:
+      msg: "k8s_cluster_id: {{ terraform_run.outputs.cluster_id.value }}"
+  when: terraform_run.outputs.cluster_id.value is defined
 
 - name: Debug node pool IDs
   debug:
       var: pool_id
-  loop: "{{ nodepool_zone1_id + nodepool_zone2_id }}"
+  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
   loop_control:
       loop_var: pool_id
-      
+
+
+#- name: Delete k8s cluster nodepool
+#  ionoscloudsdk.ionoscloud.k8s_nodepool:
+#      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default(omit) }}"
+#      nodepool_id: "{{ pool_id }}"
+#      username: "{{ ionos_username }}"
+#      password: "{{ ionos_password }}"
+#      state: absent
+#  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default(omit) + terraform_run.outputs.nodepool_zone2_id.value | default(omit)] }}"
+#  loop_control:
+#    loop_var: pool_id
+#  when: not ansible_check_mode # and terraform_run.outputs.cluster_id.value is defined and item is defined
+
 - name: Delete k8s cluster nodepool
   ionoscloudsdk.ionoscloud.k8s_nodepool:
-      k8s_cluster_id: "{{ k8s_cluster_id }}"
+      k8s_cluster_id: "{{ terraform_run.outputs.cluster_id.value | default() }}"
       nodepool_id: "{{ pool_id }}"
       username: "{{ ionos_username }}"
       password: "{{ ionos_password }}"
       state: absent
-  loop: "{{ nodepool_zone1_id + nodepool_zone2_id }}"
+  loop: "{{ [terraform_run.outputs.nodepool_zone1_id.value | default() + terraform_run.outputs.nodepool_zone2_id.value | default()] }}"
   loop_control:
     loop_var: pool_id
   when: not ansible_check_mode
-


### PR DESCRIPTION
# Description
Fix the bugs that occur when the outputs are empty (outputs: {}). This error appears when we have the 'cluster_name' in the Terraform state, but the cluster is empty

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
