### PR TITLE
OPS-5607-fix-hosts-overwrite

### DIFF
--- a/roles/squid_proxy_ha/files/99_proxy.cfg
+++ b/roles/squid_proxy_ha/files/99_proxy.cfg
@@ -1,0 +1,3 @@
+# Ansible adds the pacemaker nodes to /etc/hosts. 
+# Therefore the file must not be overwritten by cloud-init
+manage_etc_hosts: False

--- a/roles/squid_proxy_ha/tasks/hacluster.yml
+++ b/roles/squid_proxy_ha/tasks/hacluster.yml
@@ -13,7 +13,21 @@
       {{ hostvars[item]['internal_ip'] }} {{ hostname }}
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{ hostname }}"
   loop: "{{ groups[unique_ha_group] }}" 
-    
+
+- name: Check if cloud-init is present
+  stat:
+    path: /etc/cloud/cloud.cfg.d
+  register: cloud_init_config_directory
+
+- name: Make sure that cloud-init doesn't overwrite /etc/hosts
+  copy:
+    src: 99_proxy.cfg
+    dest: /etc/cloud/cloud.cfg.d/99_proxy.cfg
+    owner: root
+    group: root
+    mode: 0644
+  when: cloud_init_config_directory.stat.exists
+
 - name: Create user for cluster (always changed)
   user:
     name: "hacluster"


### PR DESCRIPTION
# Description
The cloud-init configuration by IONOS overwrites `/etc/hosts` each time the VM restarts. Because the role adds the IPs of the proxy nodes in the private network there. Removing them leads to corosync connection problems.

Add additionals steps to make sure `manage_etc_hosts` is `False` if cloud-init is present.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
