### PR TITLE
OPS-6565-replace-subdomain

### DIFF
--- a/roles/bettermarks_proxy/templates/apps.conf.j2
+++ b/roles/bettermarks_proxy/templates/apps.conf.j2
@@ -11,7 +11,6 @@ server{
     proxy_set_header Accept-Encoding "";
     # Replace bettermarks apps domain with proxy host
     sub_filter acc.{{ bettermarks_domain }} {{ bettermarks_proxy_subdomains['school'] }}.{{ bettermarks_proxy_maindomain }};
-    sub_filter {{ bettermarks_subdomain }}.{{ bettermarks_domain }} {{ proxy_subdomain }}.{{ bettermarks_proxy_maindomain }};
     sub_filter .{{ bettermarks_domain }} .{{ bettermarks_proxy_maindomain }};
     sub_filter_once off;
     sub_filter_types application/json  text/javascript;

--- a/roles/bettermarks_proxy/templates/apps.conf.j2
+++ b/roles/bettermarks_proxy/templates/apps.conf.j2
@@ -1,21 +1,5 @@
 server{
   listen 8080;
-  location /services.json {
-    proxy_hide_header 'Access-Control-Allow-Origin';
-    add_header 'Access-Control-Allow-Origin' $http_origin;
-    # Proxy to the origin
-    proxy_set_header {{ proxy_identification_header }} true;
-    proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};
-    proxy_ssl_server_name on;
-    proxy_intercept_errors off;
-    # Turn off gzip so that we can perform regex replacement
-    proxy_set_header Accept-Encoding "";
-    # Replace bettermarks apps domain with proxy host
-    sub_filter {{ bettermarks_subdomain }}.{{ bettermarks_domain }} {{ proxy_subdomain }}.{{ bettermarks_proxy_maindomain }};
-    sub_filter .{{ bettermarks_domain }} .{{ bettermarks_proxy_maindomain }};
-    sub_filter_once off;
-    sub_filter_types application/json;
-  }
   location / {
     proxy_hide_header 'Access-Control-Allow-Origin';
     add_header 'Access-Control-Allow-Origin' $http_origin;
@@ -27,6 +11,7 @@ server{
     proxy_set_header Accept-Encoding "";
     # Replace bettermarks apps domain with proxy host
     sub_filter acc.{{ bettermarks_domain }} {{ bettermarks_proxy_subdomains['school'] }}.{{ bettermarks_proxy_maindomain }};
+    sub_filter {{ bettermarks_subdomain }}.{{ bettermarks_domain }} {{ proxy_subdomain }}.{{ bettermarks_proxy_maindomain }};
     sub_filter .{{ bettermarks_domain }} .{{ bettermarks_proxy_maindomain }};
     sub_filter_once off;
     sub_filter_types application/json  text/javascript;


### PR DESCRIPTION
# Description
Change is necessary in combination with https://github.com/hpi-schul-cloud/infra-schulcloud/pull/1134 , because the endpoint behind apps-ci00 then sends "acc" as subdomain in the services.json that has to be changed to "school" for our proxy. Change discussed with bitemarks.

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
[OPS-6565](https://ticketsystem.dbildungscloud.de/browse/OPS-6565)
<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
