### PR TITLE
fix(bettermarks_proxy): allow "data:..." URLs to math symbols render correctly

### DIFF
--- a/roles/bettermarks_proxy/templates/apps.conf.j2
+++ b/roles/bettermarks_proxy/templates/apps.conf.j2
@@ -7,9 +7,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};

--- a/roles/bettermarks_proxy/templates/basic.conf.j2
+++ b/roles/bettermarks_proxy/templates/basic.conf.j2
@@ -7,9 +7,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};

--- a/roles/bettermarks_proxy/templates/school.conf.j2
+++ b/roles/bettermarks_proxy/templates/school.conf.j2
@@ -11,9 +11,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
 {% endif %}
     # Proxy to the origin
     proxy_set_header {{ proxy_identification_header }} true;
@@ -39,9 +39,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};
@@ -68,9 +68,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
 {% endif %}
     # Proxy to the origin
     proxy_set_header {{ proxy_identification_header }} true;


### PR DESCRIPTION
# Description

We were seeing UI rendering problems since CSP was enabled when bettermarks is accessed through Schulcloud. Investigation revealed that `data:image...` URLs are blocked by the current CSP header configuration.

The same configuration is already active for in bettermarks-owned domains and works there.

## Changes

`data:` is added to all `default-src` directives in bettermarks templates.

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.