### PR TITLE
perf(bettermarks_proxy): drop translations subdomain

### DIFF
--- a/roles/bettermarks_proxy/defaults/main.yml
+++ b/roles/bettermarks_proxy/defaults/main.yml
@@ -1,7 +1,6 @@
 bettermarks_proxy_enabled_instances:
   - apm
   - school
-  - translations
   - apps
   - events
   - csp-report
@@ -10,14 +9,12 @@ bettermarks_subdomains:
   school: school
   apps: apps
   events: events
-  translations: translations
   csp-report: csp-report
 bettermarks_proxy_subdomains:
   apm: apm
   school: school
   apps: apps
   events: events
-  translations: translations
   csp-report: csp-report
 bettermarks_domain: bettermarks.com
 proxy_identification_header: "x-schulcloud-proxy"


### PR DESCRIPTION
# Description

Since translation files are now served from the `apps` domain directly.
We are still seeing some low number of requests towards the translations domain, but we already deployed the the frontend that is no longer using it a week ago.
Users affected by this will either not notice or just need to reload the page.

## Links to Tickets or other pull requests

https://bettermarks.atlassian.net/browse/OT-1

## Changes

Drops the `translations` subdomain from the list of proxied subdomains.

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

Bettermarks is going to shut down `translations.bettermarks.com` in the evening of the 30th of September 2024.

## New Repos, NPM pakages or vendor scripts

None

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
