### PR TITLE
feat: add helpdesk domain

### DIFF
--- a/roles/bettermarks_proxy/defaults/main.yml
+++ b/roles/bettermarks_proxy/defaults/main.yml
@@ -4,18 +4,21 @@ bettermarks_proxy_enabled_instances:
   - apps
   - events
   - csp-report
+  - helpdesk
 bettermarks_subdomains:
   apm: apm
   school: school
   apps: apps
   events: events
   csp-report: csp-report
+  helpdesk: helpdesk
 bettermarks_proxy_subdomains:
   apm: apm
   school: school
   apps: apps
   events: events
   csp-report: csp-report
+  helpdesk: helpdesk
 bettermarks_domain: bettermarks.com
 proxy_identification_header: "x-schulcloud-proxy"
 bettermarks_proxy_ingress_enabled: false


### PR DESCRIPTION
# Description
* bettermarks wants to introduce helpdesk in the bettermarks' schulcloud instances. 
* our helpdesk is hosted at helpdesk.bettermarks.com and have no special configuration requirements for proxying.


## Changes
* Added helpdesk subdomain for proxying it via Schucloud proxy instance.
## Datasecurity
* None
## Deployment

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guideli