### PR TITLE
DBP-1407-Fix ClamAV Container Health Issues

### DIFF
--- a/roles/clamav/defaults/main.yml
+++ b/roles/clamav/defaults/main.yml
@@ -2,6 +2,8 @@ clamav_image: "clamav/clamav"
 clamav_container_name: "clamav-scan"
 clamav_scan_directory: ""
 clamav_log_path: "/var/log/clamav"
+clamav_socket_path: "/run/clamav/"
+clamav_config_path: "/etc/clamav/"
 clamav_db_path: "/var/lib/clamav" 
 clamav_folder: /clamav
 clamav_folder_owner: 0

--- a/roles/clamav/defaults/main.yml
+++ b/roles/clamav/defaults/main.yml
@@ -2,8 +2,8 @@ clamav_image: "clamav/clamav"
 clamav_container_name: "clamav-scan"
 clamav_scan_directory: ""
 clamav_log_path: "/var/log/clamav"
-clamav_socket_path: "/run/clamav/"
-clamav_config_path: "/etc/clamav/"
+clamav_socket_path: "/run/clamav"
+clamav_config_path: "/etc/clamav"
 clamav_db_path: "/var/lib/clamav" 
 clamav_folder: /clamav
 clamav_folder_owner: 0

--- a/roles/clamav/tasks/clamav_setup.yml
+++ b/roles/clamav/tasks/clamav_setup.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Add clamav user to designated group  
   become: true
   user:
@@ -18,7 +17,6 @@
     owner: "{{clamav_user_id }}"
     group: "{{clamav_group_id }}"
     mode: 0775
-
 
 - name: Create ClamAV quarantine directory
   become: true
@@ -39,6 +37,15 @@
     group: "{{ clamav_group_id }}"
     mode: "0775"
 
+- name: Create ClamAV Config directory 
+  become: true
+  file:
+    path: "{{ clamav_config_path }}"
+    state: directory
+    owner: "{{ clamav_user_id }}"
+    group: "{{ clamav_group_id }}"
+    mode: "0775"
+
 - name: Create ClamAV socket directory 
   become: true
   file:
@@ -48,14 +55,13 @@
     group: "{{ clamav_group_id }}"
     mode: "0775"
 
-- name: Copy template of clamd.conf and modify socket path
+- name: Copy template of clamd.conf
   template:
     src: clamd.conf.j2
     dest: "{{ clamav_config_path }}/clamd.conf"
     owner: "{{ clamav_user_id }}"
     group: "{{ clamav_group_id }}"
     mode: '0644'
-
 
 - name: Remove clamav-scan container if it exists
   docker_container:
@@ -79,8 +85,21 @@
     owner: "{{ clamav_folder_owner }}"
     group: "{{ clamav_folder_group }}"
 
+- name: Create systemd tmpfiles.d rule for ClamAV socket folder
+  become: true
+  copy:
+    dest: /etc/tmpfiles.d/clamav-cleanup.conf
+    content: |
+      d /run/clamav 0755 {{ clamav_user_id }} {{ clamav_group_id }} -
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Trigger tmpfiles.d rule to create /run/clamav with correct permissions
+  become: true
+  command: systemd-tmpfiles --create
+
 - name: Docker-compose up
   community.docker.docker_compose:
     project_src: "{{ clamav_folder }}"
     remove_orphans: true
-

--- a/roles/clamav/tasks/clamav_setup.yml
+++ b/roles/clamav/tasks/clamav_setup.yml
@@ -39,6 +39,23 @@
     group: "{{ clamav_group_id }}"
     mode: "0775"
 
+- name: Create ClamAV socket directory 
+  become: true
+  file:
+    path: "{{ clamav_socket_path }}"
+    state: directory
+    owner: "{{ clamav_user_id }}"
+    group: "{{ clamav_group_id }}"
+    mode: "0775"
+
+- name: Copy template of clamd.conf and modify socket path
+  template:
+    src: clamd.conf.j2
+    dest: "{{ clamav_config_path }}/clamd.conf"
+    owner: "{{ clamav_user_id }}"
+    group: "{{ clamav_group_id }}"
+    mode: '0644'
+
 
 - name: Remove clamav-scan container if it exists
   docker_container:

--- a/roles/clamav/templates/clamd.conf.j2
+++ b/roles/clamav/templates/clamd.conf.j2
@@ -104,11 +104,11 @@ LocalSocket /run/clamav/clamd.sock
 
 # Sets the group ownership on the unix socket.
 # Default: disabled (the primary group of the user running clamd)
-#LocalSocketGroup virusgroup
+LocalSocketGroup clamav
 
 # Sets the permissions on the unix socket to the specified mode.
 # Default: disabled (socket is world accessible)
-#LocalSocketMode 660
+LocalSocketMode 660
 
 # Remove stale socket after unclean shutdown.
 # Default: yes

--- a/roles/clamav/templates/clamd.conf.j2
+++ b/roles/clamav/templates/clamd.conf.j2
@@ -1,0 +1,844 @@
+
+##
+## Example config file for the Clam AV daemon
+## Please read the clamd.conf(5) manual before editing this file.
+##
+
+
+# Comment or remove the line below.
+# Example
+
+# Uncomment this option to enable logging.
+# LogFile must be writable for the user running daemon.
+# A full path is required.
+# Default: disabled
+LogFile /var/log/clamav/clamd.log
+
+# By default the log file is locked for writing - the lock protects against
+# running clamd multiple times (if want to run another clamd, please
+# copy the configuration file, change the LogFile variable, and run
+# the daemon with --config-file option).
+# This option disables log file locking.
+# Default: no
+#LogFileUnlock yes
+
+# Maximum size of the log file.
+# Value of 0 disables the limit.
+# You may use 'M' or 'm' for megabytes (1M = 1m = 1048576 bytes)
+# and 'K' or 'k' for kilobytes (1K = 1k = 1024 bytes). To specify the size
+# in bytes just don't use modifiers. If LogFileMaxSize is enabled, log
+# rotation (the LogRotate option) will always be enabled.
+# Default: 1M
+#LogFileMaxSize 2M
+
+# Log time with each message.
+# Default: no
+LogTime yes
+
+# Also log clean files. Useful in debugging but drastically increases the
+# log size.
+# Default: no
+#LogClean yes
+
+# Use system logger (can work together with LogFile).
+# Default: no
+#LogSyslog yes
+
+# Specify the type of syslog messages - please refer to 'man syslog'
+# for facility names.
+# Default: LOG_LOCAL6
+#LogFacility LOG_MAIL
+
+# Enable verbose logging.
+# Default: no
+#LogVerbose yes
+
+# Enable log rotation. Always enabled when LogFileMaxSize is enabled.
+# Default: no
+#LogRotate yes
+
+# Enable Prelude output.
+# Default: no
+#PreludeEnable yes
+#
+# Set the name of the analyzer used by prelude-admin.
+# Default: ClamAV
+#PreludeAnalyzerName ClamAV
+
+# Log additional information about the infected file, such as its
+# size and hash, together with the virus name.
+#ExtendedDetectionInfo yes
+
+# This option allows you to save a process identifier of the listening
+# daemon.
+# This file will be owned by root, as long as clamd was started by root.
+# It is recommended that the directory where this file is stored is
+# also owned by root to keep other users from tampering with it.
+# Default: disabled
+#PidFile /run/clamav/clamd.pid
+
+# Optional path to the global temporary directory.
+# Default: system specific (usually /tmp or /var/tmp).
+#TemporaryDirectory /var/tmp
+
+# Path to the database directory.
+# Default: hardcoded (depends on installation options)
+#DatabaseDirectory /var/lib/clamav
+
+# Only load the official signatures published by the ClamAV project.
+# Default: no
+#OfficialDatabaseOnly no
+
+# Return with a nonzero error code if the virus database is older than
+# the specified number of days.
+# Default: -1
+#FailIfCvdOlderThan 7
+
+# The daemon can work in local mode, network mode or both.
+# Due to security reasons we recommend the local mode.
+
+# Path to a local socket file the daemon will listen on.
+# Default: disabled (must be specified by a user)
+LocalSocket /run/clamav/clamd.sock
+LocalSocket /run/clamav/clamd.sock
+
+# Sets the group ownership on the unix socket.
+# Default: disabled (the primary group of the user running clamd)
+#LocalSocketGroup virusgroup
+
+# Sets the permissions on the unix socket to the specified mode.
+# Default: disabled (socket is world accessible)
+#LocalSocketMode 660
+
+# Remove stale socket after unclean shutdown.
+# Default: yes
+#FixStaleSocket no
+
+# TCP port address.
+# Default: no
+TCPSocket 3310
+
+# TCP address.
+# By default we bind to INADDR_ANY, probably not wise.
+# Enable the following to provide some degree of protection
+# from the outside world. This option can be specified multiple
+# times if you want to listen on multiple IPs. IPv6 is now supported.
+# Default: no
+#TCPAddr 0.0.0.0
+
+# Maximum length the queue of pending connections may grow to.
+# Default: 200
+#MaxConnectionQueueLength 30
+
+# Clamd uses FTP-like protocol to receive data from remote clients.
+# If you are using clamav-milter to balance load between remote clamd daemons
+# on firewall servers you may need to tune the options below.
+
+# Close the connection when the data size limit is exceeded.
+# The value should match your MTA's limit for a maximum attachment size.
+# Default: 100M
+#StreamMaxLength 25M
+
+# Limit port range.
+# Default: 1024
+#StreamMinPort 30000
+# Default: 2048
+#StreamMaxPort 32000
+
+# Maximum number of threads running at the same time.
+# Default: 10
+#MaxThreads 20
+
+# Waiting for data from a client socket will timeout after this time (seconds).
+# Default: 120
+#ReadTimeout 300
+
+# This option specifies the time (in seconds) after which clamd should
+# timeout if a client doesn't provide any initial command after connecting.
+# Default: 30
+#CommandReadTimeout 30
+
+# This option specifies how long to wait (in milliseconds) if the send buffer
+# is full.
+# Keep this value low to prevent clamd hanging.
+#
+# Default: 500
+#SendBufTimeout 200
+
+# Maximum number of queued items (including those being processed by
+# MaxThreads threads).
+# It is recommended to have this value at least twice MaxThreads if possible.
+# WARNING: you shouldn't increase this too much to avoid running out  of file
+# descriptors, the following condition should hold:
+# MaxThreads*MaxRecursion + (MaxQueue - MaxThreads) + 6< RLIMIT_NOFILE (usual
+# max is 1024).
+#
+# Default: 100
+#MaxQueue 200
+
+# Waiting for a new job will timeout after this time (seconds).
+# Default: 30
+#IdleTimeout 60
+
+# Don't scan files and directories matching regex
+# This directive can be used multiple times
+# Default: scan all
+#ExcludePath ^/proc/
+#ExcludePath ^/sys/
+
+# Maximum depth directories are scanned at.
+# Default: 15
+#MaxDirectoryRecursion 20
+
+# Follow directory symlinks.
+# Default: no
+#FollowDirectorySymlinks yes
+
+# Follow regular file symlinks.
+# Default: no
+#FollowFileSymlinks yes
+
+# Scan files and directories on other filesystems.
+# Default: yes
+#CrossFilesystems no
+
+# Perform a database check.
+# Default: 600 (10 min)
+#SelfCheck 600
+
+# Enable non-blocking (multi-threaded/concurrent) database reloads.
+# This feature will temporarily load a second scanning engine while scanning
+# continues using the first engine. Once loaded, the new engine takes over.
+# The old engine is removed as soon as all scans using the old engine have
+# completed.
+# This feature requires more RAM, so this option is provided in case users are
+# willing to block scans during reload in exchange for lower RAM requirements.
+# Default: yes
+#ConcurrentDatabaseReload no
+
+# Execute a command when virus is found.
+# Use the following environment variables to identify the file and virus names:
+# - $CLAM_VIRUSEVENT_FILENAME
+# - $CLAM_VIRUSEVENT_VIRUSNAME
+# In the command string, '%v' will also be replaced with the virus name.
+# Note: The '%f' filename format character has been disabled and will no longer
+# be replaced with the file name, due to command injection security concerns.
+# Use the 'CLAM_VIRUSEVENT_FILENAME' environment variable instead.
+# For the same reason, you should NOT use the environment variables in the
+# command directly, but should use it carefully from your executed script.
+# Default: no
+#VirusEvent /opt/send_virus_alert_sms.sh
+
+# Run as another user (clamd must be started by root for this option to work)
+# Default: don't drop privileges
+User clamav
+
+# Stop daemon when libclamav reports out of memory condition.
+#ExitOnOOM yes
+
+# Don't fork into background.
+# Default: no
+#Foreground yes
+
+# Enable debug messages in libclamav.
+# Default: no
+#Debug yes
+
+# Do not remove temporary files (for debug purposes).
+# Default: no
+#LeaveTemporaryFiles yes
+
+# Record metadata about the file being scanned.
+# Scan metadata is useful for file analysis purposes and for debugging scan behavior.
+# The JSON metadata will be printed after the scan is complete if Debug is enabled.
+# A metadata.json file will be written to the scan temp directory if LeaveTemporaryFiles is enabled.
+# Default: no
+#GenerateMetadataJson yes
+
+# Permit use of the ALLMATCHSCAN command. If set to no, clamd will reject
+# any ALLMATCHSCAN command as invalid.
+# Default: yes
+#AllowAllMatchScan no
+
+# Detect Possibly Unwanted Applications.
+# Default: no
+#DetectPUA yes
+
+# Exclude a specific PUA category. This directive can be used multiple times.
+# See https://github.com/vrtadmin/clamav-faq/blob/master/faq/faq-pua.md for
+# the complete list of PUA categories.
+# Default: Load all categories (if DetectPUA is activated)
+#ExcludePUA NetTool
+#ExcludePUA PWTool
+
+# Only include a specific PUA category. This directive can be used multiple
+# times.
+# Default: Load all categories (if DetectPUA is activated)
+#IncludePUA Spy
+#IncludePUA Scanner
+#IncludePUA RAT
+
+# This option causes memory or nested map scans to dump the content to disk.
+# If you turn on this option, more data is written to disk and is available
+# when the LeaveTemporaryFiles option is enabled.
+#ForceToDisk yes
+
+# This option allows you to disable the caching feature of the engine. By
+# default, the engine will store an MD5 in a cache of any files that are
+# not flagged as virus or that hit limits checks. Disabling the cache will
+# have a negative performance impact on large scans.
+# Default: no
+#DisableCache yes
+
+# This option allows you to set the number of entries the cache can store.
+# The value should be a square number or will be rounded up to the nearest
+# square number.
+#CacheSize 65536
+
+# In some cases (eg. complex malware, exploits in graphic files, and others),
+# ClamAV uses special algorithms to detect abnormal patterns and behaviors that
+# may be malicious.  This option enables alerting on such heuristically
+# detected potential threats.
+# Default: yes
+#HeuristicAlerts no
+
+# Allow heuristic alerts to take precedence.
+# When enabled, if a heuristic scan (such as phishingScan) detects
+# a possible virus/phish it will stop scan immediately. Recommended, saves CPU
+# scan-time.
+# When disabled, virus/phish detected by heuristic scans will be reported only
+# at the end of a scan. If an archive contains both a heuristically detected
+# virus/phish, and a real malware, the real malware will be reported
+#
+# Keep this disabled if you intend to handle "Heuristics.*" viruses
+# differently from "real" malware.
+# If a non-heuristically-detected virus (signature-based) is found first,
+# the scan is interrupted immediately, regardless of this config option.
+#
+# Default: no
+#HeuristicScanPrecedence yes
+
+
+##
+## Heuristic Alerts
+##
+
+# With this option clamav will try to detect broken executables (both PE and
+# ELF) and alert on them with the Broken.Executable heuristic signature.
+# Default: no
+#AlertBrokenExecutables yes
+
+# With this option clamav will try to detect broken media file (JPEG,
+# TIFF, PNG, GIF) and alert on them with a Broken.Media heuristic signature.
+# Default: no
+#AlertBrokenMedia yes
+
+# Alert on encrypted archives _and_ documents with heuristic signature
+# (encrypted .zip, .7zip, .rar, .pdf).
+# Default: no
+#AlertEncrypted yes
+
+# Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip,
+# .rar).
+# Default: no
+#AlertEncryptedArchive yes
+
+# Alert on encrypted archives with heuristic signature (encrypted .pdf).
+# Default: no
+#AlertEncryptedDoc yes
+
+# With this option enabled OLE2 files containing VBA macros, which were not
+# detected by signatures will be marked as "Heuristics.OLE2.ContainsMacros".
+# Default: no
+#AlertOLE2Macros yes
+
+# Alert on SSL mismatches in URLs, even if the URL isn't in the database.
+# This can lead to false positives.
+# Default: no
+#AlertPhishingSSLMismatch yes
+
+# Alert on cloaked URLs, even if URL isn't in database.
+# This can lead to false positives.
+# Default: no
+#AlertPhishingCloak yes
+
+# Alert on raw DMG image files containing partition intersections
+# Default: no
+#AlertPartitionIntersection yes
+
+
+##
+## Executable files
+##
+
+# PE stands for Portable Executable - it's an executable file format used
+# in all 32 and 64-bit versions of Windows operating systems. This option
+# allows ClamAV to perform a deeper analysis of executable files and it's also
+# required for decompression of popular executable packers such as UPX, FSG,
+# and Petite. If you turn off this option, the original files will still be
+# scanned, but without additional processing.
+# Default: yes
+#ScanPE no
+
+# Certain PE files contain an authenticode signature. By default, we check
+# the signature chain in the PE file against a database of trusted and
+# revoked certificates if the file being scanned is marked as a virus.
+# If any certificate in the chain validates against any trusted root, but
+# does not match any revoked certificate, the file is marked as trusted.
+# If the file does match a revoked certificate, the file is marked as virus.
+# The following setting completely turns off authenticode verification.
+# Default: no
+#DisableCertCheck yes
+
+# Executable and Linking Format is a standard format for UN*X executables.
+# This option allows you to control the scanning of ELF files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanELF no
+
+
+##
+## Documents
+##
+
+# This option enables scanning of OLE2 files, such as Microsoft Office
+# documents and .msi files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanOLE2 no
+
+# This option enables scanning within PDF files.
+# If you turn off this option, the original files will still be scanned, but
+# without decoding and additional processing.
+# Default: yes
+#ScanPDF no
+
+# This option enables scanning within SWF files.
+# If you turn off this option, the original files will still be scanned, but
+# without decoding and additional processing.
+# Default: yes
+#ScanSWF no
+
+# This option enables scanning xml-based document files supported by libclamav.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanXMLDOCS no
+
+# This option enables scanning of HWP3 files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanHWP3 no
+
+# This option enables scanning of OneNote files.
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanOneNote no
+
+
+##
+## Other file types
+##
+
+# This option enables scanning of image (graphics).
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+# Default: yes
+#ScanImage no
+
+# This option enables detection by calculating a fuzzy hash of image (graphics)
+# files.
+# Signatures using image fuzzy hashes typically match files and documents by
+# identifying images embedded or attached to those files.
+# If you turn off this option, then some files may no longer be detected.
+# Default: yes
+#ScanImageFuzzyHash no
+
+
+##
+## Mail files
+##
+
+# Enable internal e-mail scanner.
+# If you turn off this option, the original files will still be scanned, but
+# without parsing individual messages/attachments.
+# Default: yes
+#ScanMail no
+
+# Scan RFC1341 messages split over many emails.
+# You will need to periodically clean up $TemporaryDirectory/clamav-partial
+# directory.
+# WARNING: This option may open your system to a DoS attack.
+#          Never use it on loaded servers.
+# Default: no
+#ScanPartialMessages yes
+
+# With this option enabled ClamAV will try to detect phishing attempts by using
+# HTML.Phishing and Email.Phishing NDB signatures.
+# Default: yes
+#PhishingSignatures no
+
+# With this option enabled ClamAV will try to detect phishing attempts by
+# analyzing URLs found in emails using WDB and PDB signature databases.
+# Default: yes
+#PhishingScanURLs no
+
+
+##
+## Data Loss Prevention (DLP)
+##
+
+# Enable the DLP module
+# Default: No
+#StructuredDataDetection yes
+
+# This option sets the lowest number of Credit Card numbers found in a file
+# to generate a detect.
+# Default: 3
+#StructuredMinCreditCardCount 5
+
+# With this option enabled the DLP module will search for valid Credit Card
+# numbers only. Debit and Private Label cards will not be searched.
+# Default: no
+#StructuredCCOnly yes
+
+# This option sets the lowest number of Social Security Numbers found
+# in a file to generate a detect.
+# Default: 3
+#StructuredMinSSNCount 5
+
+# With this option enabled the DLP module will search for valid
+# SSNs formatted as xxx-yy-zzzz
+# Default: yes
+#StructuredSSNFormatNormal no
+
+# With this option enabled the DLP module will search for valid
+# SSNs formatted as xxxyyzzzz
+# Default: no
+#StructuredSSNFormatStripped yes
+
+
+##
+## HTML
+##
+
+# Perform HTML normalisation and decryption of MS Script Encoder code.
+# Default: yes
+# If you turn off this option, the original files will still be scanned, but
+# without additional processing.
+#ScanHTML no
+
+
+##
+## Archives
+##
+
+# ClamAV can scan within archives and compressed files.
+# If you turn off this option, the original files will still be scanned, but
+# without unpacking and additional processing.
+# Default: yes
+#ScanArchive no
+
+
+##
+## Limits
+##
+
+# The options below protect your system against Denial of Service attacks
+# using archive bombs.
+
+# This option sets the maximum amount of time to a scan may take.
+# In this version, this field only affects the scan time of ZIP archives.
+# Value of 0 disables the limit.
+# Note: disabling this limit or setting it too high may result allow scanning
+# of certain files to lock up the scanning process/threads resulting in a
+# Denial of Service.
+# Time is in milliseconds.
+# Default: 120000
+#MaxScanTime 300000
+
+# This option sets the maximum amount of data to be scanned for each input
+# file. Archives and other containers are recursively extracted and scanned
+# up to this value.
+# Value of 0 disables the limit
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 400M
+#MaxScanSize 1000M
+
+# Files larger than this limit won't be scanned. Affects the input file itself
+# as well as files contained inside it (when the input file is an archive, a
+# document or some other kind of container).
+# Value of 0 disables the limit.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Technical design limitations prevent ClamAV from scanning files greater than
+# 2 GB at this time.
+# Default: 100M
+#MaxFileSize 400M
+
+# Nested archives are scanned recursively, e.g. if a Zip archive contains a RAR
+# file, all files within it will also be scanned. This options specifies how
+# deeply the process should be continued.
+# Note: setting this limit too high may result in severe damage to the system.
+# Default: 17
+#MaxRecursion 10
+
+# Number of files to be scanned within an archive, a document, or any other
+# container file.
+# Value of 0 disables the limit.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 10000
+#MaxFiles 15000
+
+# Maximum size of a file to check for embedded PE. Files larger than this value
+# will skip the additional analysis step.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 40M
+#MaxEmbeddedPE 100M
+
+# Maximum size of a HTML file to normalize. HTML files larger than this value
+# will not be normalized or scanned.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 40M
+#MaxHTMLNormalize 100M
+
+# Maximum size of a normalized HTML file to scan. HTML files larger than this
+# value after normalization will not be scanned.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 8M
+#MaxHTMLNoTags 16M
+
+# Maximum size of a script file to normalize. Script content larger than this
+# value will not be normalized or scanned.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 20M
+#MaxScriptNormalize 50M
+
+# Maximum size of a ZIP file to reanalyze type recognition. ZIP files larger
+# than this value will skip the step to potentially reanalyze as PE.
+# Note: disabling this limit or setting it too high may result in severe damage
+# to the system.
+# Default: 1M
+#MaxZipTypeRcg 1M
+
+# This option sets the maximum number of partitions of a raw disk image to be
+# scanned.
+# Raw disk images with more partitions than this value will have up to
+# the value number partitions scanned. Negative values are not allowed.
+# Note: setting this limit too high may result in severe damage or impact
+# performance.
+# Default: 50
+#MaxPartitions 128
+
+# This option sets the maximum number of icons within a PE to be scanned.
+# PE files with more icons than this value will have up to the value number
+# icons scanned.
+# Negative values are not allowed.
+# WARNING: setting this limit too high may result in severe damage or impact
+# performance.
+# Default: 100
+#MaxIconsPE 200
+
+# This option sets the maximum recursive calls for HWP3 parsing during
+# scanning. HWP3 files using more than this limit will be terminated and
+# alert the user.
+# Scans will be unable to scan any HWP3 attachments if the recursive limit
+# is reached.
+# Negative values are not allowed.
+# WARNING: setting this limit too high may result in severe damage or impact
+# performance.
+# Default: 16
+#MaxRecHWP3 16
+
+# This option sets the maximum calls to the PCRE match function during
+# an instance of regex matching.
+# Instances using more than this limit will be terminated and alert the user
+# but the scan will continue.
+# For more information on match_limit, see the PCRE documentation.
+# Negative values are not allowed.
+# WARNING: setting this limit too high may severely impact performance.
+# Default: 100000
+#PCREMatchLimit 20000
+
+# This option sets the maximum recursive calls to the PCRE match function
+# during an instance of regex matching.
+# Instances using more than this limit will be terminated and alert the user
+# but the scan will continue.
+# For more information on match_limit_recursion, see the PCRE documentation.
+# Negative values are not allowed and values > PCREMatchLimit are superfluous.
+# WARNING: setting this limit too high may severely impact performance.
+# Default: 2000
+#PCRERecMatchLimit 10000
+
+# This option sets the maximum filesize for which PCRE subsigs will be
+# executed. Files exceeding this limit will not have PCRE subsigs executed
+# unless a subsig is encompassed to a smaller buffer.
+# Negative values are not allowed.
+# Setting this value to zero disables the limit.
+# WARNING: setting this limit too high or disabling it may severely impact
+# performance.
+# Default: 100M
+#PCREMaxFileSize 400M
+
+# When AlertExceedsMax is set, files exceeding the MaxFileSize, MaxScanSize, or
+# MaxRecursion limit will be flagged with the virus name starting with
+# "Heuristics.Limits.Exceeded".
+# Default: no
+#AlertExceedsMax yes
+
+##
+## On-access Scan Settings
+##
+
+# Don't scan files larger than OnAccessMaxFileSize
+# Value of 0 disables the limit.
+# Default: 5M
+#OnAccessMaxFileSize 10M
+
+# Max number of scanning threads to allocate to the OnAccess thread pool at
+# startup. These threads are the ones responsible for creating a connection
+# with the daemon and kicking off scanning after an event has been processed.
+# To prevent clamonacc from consuming all clamd's resources keep this lower
+# than clamd's max threads.
+# Default: 5
+#OnAccessMaxThreads 10
+
+# Max amount of time (in milliseconds) that the OnAccess client should spend
+# for every connect, send, and receive attempt when communicating with clamd
+# via curl.
+# Default: 5000 (5 seconds)
+# OnAccessCurlTimeout 10000
+
+# Toggles dynamic directory determination. Allows for recursively watching
+# include paths.
+# Default: no
+#OnAccessDisableDDD yes
+
+# Set the include paths (all files inside them will be scanned). You can have
+# multiple OnAccessIncludePath directives but each directory must be added
+# in a separate line.
+# Default: disabled
+#OnAccessIncludePath /home
+#OnAccessIncludePath /students
+
+# Set the exclude paths. All subdirectories are also excluded.
+# Default: disabled
+#OnAccessExcludePath /home/user
+
+# Modifies fanotify blocking behaviour when handling permission events.
+# If off, fanotify will only notify if the file scanned is a virus,
+# and not perform any blocking.
+# Default: no
+#OnAccessPrevention yes
+
+# When using prevention, if this option is turned on, any errors that occur
+# during scanning will result in the event attempt being denied. This could
+# potentially lead to unwanted system behaviour with certain configurations,
+# so the client defaults this to off and prefers allowing access events in
+# case of scan or connection error.
+# Default: no
+#OnAccessDenyOnError yes
+
+# Toggles extra scanning and notifications when a file or directory is
+# created or moved.
+# Requires the  DDD system to kick-off extra scans.
+# Default: no
+#OnAccessExtraScanning yes
+
+# Set the  mount point to be scanned. The mount point specified, or the mount
+# point containing the specified directory will be watched. If any directories
+# are specified, this option will preempt (disable and ignore all options
+# related to) the DDD system. This option will result in verdicts only.
+# Note that prevention is explicitly disallowed to prevent common, fatal
+# misconfigurations. (e.g. watching "/" with prevention on and no exclusions
+# made on vital system directories)
+# It can be used multiple times.
+# Default: disabled
+#OnAccessMountPath /
+#OnAccessMountPath /home/user
+
+# With this option you can exclude the root UID (0). Processes run under
+# root with be able to access all files without triggering scans or
+# permission denied events.
+# Note that if clamd cannot check the uid of the process that generated an
+# on-access scan event (e.g., because OnAccessPrevention was not enabled, and
+# the process already exited), clamd will perform a scan.  Thus, setting
+# OnAccessExcludeRootUID is not *guaranteed* to prevent every access by the
+# root user from triggering a scan (unless OnAccessPrevention is enabled).
+# Default: no
+#OnAccessExcludeRootUID no
+
+# With this option you can exclude specific UIDs. Processes with these UIDs
+# will be able to access all files without triggering scans or permission
+# denied events.
+# This option can be used multiple times (one per line).
+# Using a value of 0 on any line will disable this option entirely.
+# To exclude the root UID (0) please enable the OnAccessExcludeRootUID
+# option.
+# Also note that if clamd cannot check the uid of the process that generated an
+# on-access scan event (e.g., because OnAccessPrevention was not enabled, and
+# the process already exited), clamd will perform a scan.  Thus, setting
+# OnAccessExcludeUID is not *guaranteed* to prevent every access by the
+# specified uid from triggering a scan (unless OnAccessPrevention is enabled).
+# Default: disabled
+#OnAccessExcludeUID -1
+
+# This option allows exclusions via user names when using the on-access
+# scanning client. It can be used multiple times.
+# It has the same potential race condition limitations of the
+# OnAccessExcludeUID option.
+# Default: disabled
+#OnAccessExcludeUname clamav
+
+# Number of times the OnAccess client will retry a failed scan due to
+# connection problems (or other issues).
+# Default: 0
+#OnAccessRetryAttempts 3
+
+##
+## Bytecode
+##
+
+# With this option enabled ClamAV will load bytecode from the database.
+# It is highly recommended you keep this option on, otherwise you'll miss
+# detections for many new viruses.
+# Default: yes
+#Bytecode no
+
+# Set bytecode security level.
+# Possible values:
+#   None -      No security at all, meant for debugging.
+#               DO NOT USE THIS ON PRODUCTION SYSTEMS.
+#               This value is only available if clamav was built
+#               with --enable-debug!
+#   TrustSigned - Trust bytecode loaded from signed .c[lv]d files, insert
+#               runtime safety checks for bytecode loaded from other sources.
+#   Paranoid -  Don't trust any bytecode, insert runtime checks for all.
+# Recommended: TrustSigned, because bytecode in .cvd files already has these
+# checks.
+# Note that by default only signed bytecode is loaded, currently you can only
+# load unsigned bytecode in --enable-debug mode.
+#
+# Default: TrustSigned
+#BytecodeSecurity TrustSigned
+
+# Allow loading bytecode from outside digitally signed .c[lv]d files.
+# **Caution**: You should NEVER run bytecode signatures from untrusted sources.
+# Doing so may result in arbitrary code execution.
+# Default: no
+#BytecodeUnsigned yes
+
+# Set bytecode timeout in milliseconds.
+#
+# Default: 10000
+# BytecodeTimeout 1000

--- a/roles/clamav/templates/docker-compose.yml.j2
+++ b/roles/clamav/templates/docker-compose.yml.j2
@@ -16,7 +16,6 @@ services:
       - "{{ clamav_config_path }}/clamd.conf:/etc/clamav/clamd.conf:ro"
       - "{{ clamav_socket_path }}:/run/clamav:rw"
       - "{{ clamav_quarantine_path + ':/quarantine:rw' if clamav_quarantine  else '' }}"
-
     tmpfs:
       - /tmp:rw,mode=777
     entrypoint: "/init-unprivileged"

--- a/roles/clamav/templates/docker-compose.yml.j2
+++ b/roles/clamav/templates/docker-compose.yml.j2
@@ -13,7 +13,9 @@ services:
       - "{{ clamav_scan_directory + ':/scanned:rw' if clamav_scan_directory | length > 0 else '' }}"
       - "{{ clamav_log_path }}:/var/log/clamav:rw"
       - "{{ clamav_db_path }}:/var/lib/clamav:rw"
+      - "{{ clamav_config_path }}/clamd.conf:/etc/clamav/clamd.conf:ro"
       - "{{ clamav_quarantine_path + ':/quarantine:rw' if clamav_quarantine  else '' }}"
+
     tmpfs:
       - /tmp:rw,mode=777
     entrypoint: "/init-unprivileged"

--- a/roles/clamav/templates/docker-compose.yml.j2
+++ b/roles/clamav/templates/docker-compose.yml.j2
@@ -14,6 +14,7 @@ services:
       - "{{ clamav_log_path }}:/var/log/clamav:rw"
       - "{{ clamav_db_path }}:/var/lib/clamav:rw"
       - "{{ clamav_config_path }}/clamd.conf:/etc/clamav/clamd.conf:ro"
+      - "{{ clamav_socket_path }}:/run/clamav:rw"
       - "{{ clamav_quarantine_path + ':/quarantine:rw' if clamav_quarantine  else '' }}"
 
     tmpfs:


### PR DESCRIPTION
**Motivation:**
The ClamAV container is currently unhealthy due to socket permission issues, preventing it from starting correctly

**To do list:**
          - Determine why the container is unhealthy.
          - Key errors:
          - WARNING: Clamd was NOT notified: Can't connect to clamd through /tmp/clamd.sock: Connection refused
          - Can't unlink the socket file /run/clamav/clamd.sock
          - Change the socket location from /tmp/clamd.sock to /var/run/clamav/clamd.sock
          - Mount the socket directory permanently from the host
          - After reboot:
                  1. /run/clamav/ gets recreated automatically by the host, owned by root:root
                  2.  But your ClamAV container runs as a non-root user (e.g. UID=2330, GID=996)
                  3. ClamAV cannot bind the socket at /run/clamav/clamd.sock
**Acceptance criteria (testable):**
          - The container runs successfully, even after a reboot.