### PR TITLE
fix(bettermarks_proxy): always use 'always' with add_header

### DIFF
--- a/roles/bettermarks_proxy/templates/apps.conf.j2
+++ b/roles/bettermarks_proxy/templates/apps.conf.j2
@@ -7,9 +7,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp" always;
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only" always;
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};

--- a/roles/bettermarks_proxy/templates/basic.conf.j2
+++ b/roles/bettermarks_proxy/templates/basic.conf.j2
@@ -7,9 +7,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp" always;
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only" always;
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};

--- a/roles/bettermarks_proxy/templates/helpdesk.conf.j2
+++ b/roles/bettermarks_proxy/templates/helpdesk.conf.j2
@@ -7,9 +7,9 @@ server{
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp" always;
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only" always;
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};

--- a/roles/bettermarks_proxy/templates/school.conf.j2
+++ b/roles/bettermarks_proxy/templates/school.conf.j2
@@ -6,14 +6,14 @@ server{
     # Re-add the header with calling origin.
     add_header 'Access-Control-Allow-Origin' $http_origin always;
     proxy_hide_header 'Access-Control-Allow-Credentials';
-    add_header 'Access-Control-Allow-Credentials' true;
+    add_header 'Access-Control-Allow-Credentials' true always;
     # Hide original CSP Headers
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp" always;
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only" always;
 {% endif %}
     # Proxy to the origin
     proxy_set_header {{ proxy_identification_header }} true;
@@ -34,14 +34,14 @@ server{
     # Re-add the header with calling origin.
     add_header 'Access-Control-Allow-Origin' $http_origin always;
     proxy_hide_header 'Access-Control-Allow-Credentials';
-    add_header 'Access-Control-Allow-Credentials' true;
+    add_header 'Access-Control-Allow-Credentials' true always;
     # Hide original CSP Headers
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp" always;
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only" always;
 {% endif %}
     proxy_set_header {{ proxy_identification_header }} true;
     proxy_pass https://{{ bettermarks_subdomain }}.{{ bettermarks_domain }};
@@ -63,14 +63,14 @@ server{
     # Re-add the header with calling origin.
     add_header 'Access-Control-Allow-Origin' $http_origin always;
     proxy_hide_header 'Access-Control-Allow-Credentials';
-    add_header 'Access-Control-Allow-Credentials' true;
+    add_header 'Access-Control-Allow-Credentials' true always;
     # Hide original CSP Headers
     proxy_hide_header 'Content-Security-Policy';
     proxy_hide_header 'Content-Security-Policy-Report-Only';
 {% if bettermarks_proxy_csp_enabled and bettermarks_proxy_csp_enforced %}
-    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp";
+    add_header 'Content-Security-Policy' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp" always;
 {% elif bettermarks_proxy_csp_enabled %}
-    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only";
+    add_header 'Content-Security-Policy-Report-Only' "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.{{ bettermarks_proxy_maindomain }} *.{{ bettermarks_instancedomain }} {{ bettermarks_instancedomain }}; report-uri https://{{ bettermarks_proxy_subdomains['csp-report'] }}.{{ bettermarks_proxy_maindomain }}/csp/report-only" always;
 {% endif %}
     # Proxy to the origin
     proxy_set_header {{ proxy_identification_header }} true;


### PR DESCRIPTION
# Description

This is a follow-up to https://github.com/hpi-schul-cloud/infra-ansible-collections/pull/176. We noticed that there are remaining cases with CORS errors due to `Access-Control-Allow-Credentials` not always being set, and also realized that CSP headers were set with the same implicit conditional via `add_header`.

## Changes

Add `always` param to all uses of `add_header`.

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
